### PR TITLE
Bug fix: Preventing infinite loop after installing a native dependency package.

### DIFF
--- a/lib/tpkg.rb
+++ b/lib/tpkg.rb
@@ -3434,6 +3434,7 @@ class Tpkg
       elsif pkg[:source] == :native_available
         os.upgrade_native_package(pkg)
         has_updates = true
+        @available_native_packages.delete(pkg[:metadata][:name]) # to have the status of this native package reloaded
       else  # tpkg
         pkgfile = nil
         if File.file?(pkg[:source])


### PR DESCRIPTION
Currently "tpkg --upgrade" falls in an infinite loop after installing a native dependency package.

This can happen when a new version of a tpkg package introduces a new native dependency.
Then, the first upgrade attempt always gets stuck.
The second attempt will succeed since the required native package was installed during the first attempt.
However, this gets worse if the first attempt was made from a daemon(e.g. Etch), which will continue to run calculating the tpkg checksum(hash) over and over again wasting significant CPU time.

It is caused by a lack of update of @available_native_packages after installing a native package. installed_packages_that_meet_requirement( ) at line 4092 returns nil for the native package even after its installation, and the tpkg being upgraded is pushed back to the queue again and again by line 4096 making an infinite loop.

This can be avoided by simply deleting the native package data from @available_native_packages after installing it and let the data reloaded when queried.

Jae Park
