### PR TITLE
Fix removal of symlinks to directories

### DIFF
--- a/lib/tpkg.rb
+++ b/lib/tpkg.rb
@@ -3693,7 +3693,7 @@ class Tpkg
         # don't remove conf files that have been modified
         next if modified_conf_files.include?(file)
         begin
-          if !File.directory?(file)
+          if File.symlink?(file) || !File.directory?(file)
             File.delete(file)
           else
             begin


### PR DESCRIPTION
When a file is a symlink to a directory, File.directory?(file) returns true, and the script used to try to delete it with Dir.delete( ) which would fail and be rescued silently as if it were a non-empty directory.
A symlink needs to be tested with File.symlink?( ) and deleted with File.delete( ).
This resolves [issue#37](https://github.com/tpkg/client/issues/37)
