### PR TITLE
Fix script-not-executable warning

### DIFF
--- a/bin/tpkg
+++ b/bin/tpkg
@@ -445,7 +445,7 @@ end
 if @groups
   settings = parse_config_files
   if settings[:host_group_script]
-    if !File.executable?(settings[:host_group_script])
+    if !File.executable?(settings[:host_group_script].split(' ').first)
       warn "Warning: host group script #{settings[:host_group_script]} is not executable, execution will likely fail"
     end
     servers = []


### PR DESCRIPTION
when command-line option is used.
e.g. host_group_script = /usr/bin/nv --nge
