### PR TITLE
Add back get_arch/os for backward compatibility

### DIFF
--- a/lib/tpkg.rb
+++ b/lib/tpkg.rb
@@ -669,7 +669,21 @@ class Tpkg
     Dir.mkdir(tmpdir)
     tmpdir
   end
-  
+
+  # Backward compatibility method. Use tpkg.os.arch instead.
+  @@arch = nil
+  def self.get_arch
+    @@arch = Tpkg::OS.create().arch if @@arch.nil?
+    @@arch.dup
+  end
+
+  # Backward compatibility method. Use tpkg.os.os instead.
+  @@os = nil
+  def self.get_os
+    @@os = Tpkg::OS.create().os if @@os.nil?
+    @@os.dup
+  end
+
   # Given an array of pkgs. Determine if any of those package
   # satisfy the requirement specified by req
   def packages_meet_requirement?(pkgs, req)


### PR DESCRIPTION
The removal of get_os method breaks many of our autobuild scripts.
It would be nice if you can add them back and release a new version for gem.
