### PR TITLE
Set TPKG_ACTION ENV var on remove or upgrade.

### DIFF
--- a/lib/tpkg.rb
+++ b/lib/tpkg.rb
@@ -3525,6 +3525,12 @@ class Tpkg
   def remove(requests=nil, options={})
     ret_val = 0
     lock
+
+    if options[:upgrade]
+       ENV['TPKG_ACTION'] = "upgrade"
+    else
+       ENV['TPKG_ACTION'] = "remove"
+    end
     
     packages_to_remove = nil
     if requests


### PR DESCRIPTION
Set TPKG_ACTION ENV var on remove or upgrade. This allows for symmetry between preinstall/preremove and postinstall/postremove. It is the complement to the following:

```
  def unpack(package_file, options={})
    ret_val = 0

    # set env variable to let pre/post install know  whether this unpack
    # is part of an install or upgrade
    if options[:is_doing_upgrade]
       ENV['TPKG_ACTION'] = "upgrade"
    else
       ENV['TPKG_ACTION'] = "install"
    End
```