### PR TITLE
Fix popen3 cmd exit status checking

### DIFF
--- a/lib/tpkg/os/debian.rb
+++ b/lib/tpkg/os/debian.rb
@@ -53,7 +53,7 @@ class Tpkg::OS::Debian < Tpkg::OS
         end
       end
       stderr_first_line = stderr.gets
-      exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's peopen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
+      exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's popen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
     end
     if !exit_status.success?
       # Ignore 'no matching packages', raise anything else

--- a/lib/tpkg/os/freebsd.rb
+++ b/lib/tpkg/os/freebsd.rb
@@ -57,7 +57,7 @@ class Tpkg::OS::FreeBSD < Tpkg::OS
             pkgname, version, package_version, :native_installed)
       end
       stderr_first_line = stderr.gets
-      exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's peopen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
+      exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's popen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
     end
     if !exit_status.success?
       # Ignore 'no matching packages', raise anything else

--- a/lib/tpkg/os/redhat.rb
+++ b/lib/tpkg/os/redhat.rb
@@ -63,7 +63,7 @@ class Tpkg::OS::RedHat < Tpkg::OS
           end
         end
         stderr_first_line = stderr.gets
-        exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's peopen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
+        exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's popen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
       end
       if !exit_status.success?
         # Ignore 'no matching packages', raise anything else

--- a/lib/tpkg/os/redhat.rb
+++ b/lib/tpkg/os/redhat.rb
@@ -30,7 +30,8 @@ class Tpkg::OS::RedHat < Tpkg::OS
       cmd = "#{@yumcmd} info #{yum[:arg]} #{pkgname}"
       puts "available_native_packages running '#{cmd}'" if @debug
       stderr_first_line = nil
-      Open3.popen3(cmd) do |stdin, stdout, stderr|
+      exit_status = nil
+      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
         stdin.close
         read_packages = false
         name = version = package_version = nil
@@ -62,9 +63,9 @@ class Tpkg::OS::RedHat < Tpkg::OS
           end
         end
         stderr_first_line = stderr.gets
+        exit_status = wait_thr ? wait_thr.value : $?	# Pre-1.9 Ruby's peopen3 doesn't return the thread. $? is not correct, but it was used here instead of Thread.value for a long time.
       end
-      # FIXME: popen3 doesn't set $?
-      if !$?.success?
+      if !exit_status.success?
         # Ignore 'no matching packages', raise anything else
         if stderr_first_line != "Error: No matching Packages to list\n"
           raise "available_native_packages error running yum"

--- a/lib/tpkg/version.rb
+++ b/lib/tpkg/version.rb
@@ -1,3 +1,3 @@
 class Tpkg
-  VERSION = '2.3.5'
+  VERSION = '2.3.6'
 end


### PR DESCRIPTION
The old method starts to fail in RedHat7.
Need to use Thread.value instead of $?.