### PR TITLE
Makes sure we don't overwrite ActionController::Parameters.dup()

### DIFF
--- a/lib/tpkg/metadata.rb
+++ b/lib/tpkg/metadata.rb
@@ -141,6 +141,15 @@ class HashWithIndifferentAccess < Hash
     end
 end
 
+module ActionController
+end
+
+class ActionController::Parameters < HashWithIndifferentAccess
+  def dup
+    super.dup
+  end
+end
+
 module IndifferentAccess 
   def with_indifferent_access
     hash = HashWithIndifferentAccess.new(self)


### PR DESCRIPTION
Makes sure we don't overwrite ActionController::Parameters.dup() defined by ActionPack library.
Bug was introduced when Rails 4.0 introduced a permitted? function to ActionController::Parameters with Strong Parameters, and Rails 4.1 started using it on Parameters duplicated using the dup() method, resulting in a MethodNotFound exception. This fix makes sure we don't overwrite the dup() method just because Parameters includes HashWithIndifferentAccess.