### PR TITLE
Etc getlogin inconsistent

### DIFF
--- a/bin/tpkg_uploader
+++ b/bin/tpkg_uploader
@@ -21,7 +21,7 @@ tpkg_upload_url = "http://localhost:3000/uploads/create"
 proxy_server = "proxy.local:8080"
 ##########################################################################
 
-username = Etc.getlogin
+username = Etc.getpwuid.name
 password = nil
 files_to_upload = nil
 proxy = ""

--- a/lib/tpkg.rb
+++ b/lib/tpkg.rb
@@ -4159,7 +4159,7 @@ class Tpkg
   # log changes of pkgs that were installed/removed
   def log_changes(options={})
     msg = ""
-    user = Etc.getlogin || Etc.getpwuid(Process.uid).name
+    user = Etc.getpwuid.name
     newly_installed = removed = []
     newly_installed = options[:newly_installed] if options[:newly_installed]
     removed = options[:removed] if options[:removed]
@@ -4178,7 +4178,7 @@ class Tpkg
 
   def send_update_to_server(options={})
     request = {"client"=>os.fqdn}
-    request[:user] = Etc.getlogin || Etc.getpwuid(Process.uid).name
+    request[:user] = Etc.getpwuid.name
     request[:tpkg_home] = ENV['TPKG_HOME']
 
     if options[:currently_installed]

--- a/lib/tpkg/deployer.rb
+++ b/lib/tpkg/deployer.rb
@@ -34,7 +34,7 @@ class Deployer
     @max_worker = 4
     @abort_on_failure = false
     @use_ssh_key = false
-    @user = Etc.getlogin
+    @user = Etc.getpwuid.name
     @password = nil
     unless options.nil?
       @user = options["deploy-as"] unless options["deploy-as"].nil?

--- a/lib/tpkg/version.rb
+++ b/lib/tpkg/version.rb
@@ -1,3 +1,3 @@
 class Tpkg
-  VERSION = '2.3.6'
+  VERSION = '2.3.7'
 end


### PR DESCRIPTION
Etc.getlogin returns either the real username or the effective username depending how the shell was acquired. It's an undesirable inconsistency. Etc.getpwuid.name always yields the effective username.